### PR TITLE
Fix result caching on refresh and add scroll to Icon in shared links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,8 +22,7 @@ import Footer from './components/Footer'
 import ThankYou from './components/ThankYou'
 import ScrollToTopBtn from './components/ScrollToTop'
 import AppContext from './utils/AppContext'
-import CookiesBanner from './components/CookiesBanner'
-import StartOnTop from './components/StartOnTop'
+import CookiesBanner from './components/CookiesBanner' 
 
 const tagManagerArgs = {
   gtmId: GTM
@@ -39,7 +38,6 @@ const App = () => {
         <Navigation />
         <div className='app-container'>
           <Router primary={false}>
-            <StartOnTop path='/'>
               <Home path='/' />
               <Docs path='/docs' />
               <CookiesPage path='/cookies-policy' />
@@ -48,7 +46,6 @@ const App = () => {
               <AboutPage path='/about' />
               <TeamPage path='/team' />
               <Cheatsheet path='/cheatsheet' />
-            </StartOnTop>
           </Router>
           <ScrollToTopBtn />
         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ import Footer from './components/Footer'
 import ThankYou from './components/ThankYou'
 import ScrollToTopBtn from './components/ScrollToTop'
 import AppContext from './utils/AppContext'
-import CookiesBanner from './components/CookiesBanner' 
+import CookiesBanner from './components/CookiesBanner'
 
 const tagManagerArgs = {
   gtmId: GTM
@@ -38,14 +38,14 @@ const App = () => {
         <Navigation />
         <div className='app-container'>
           <Router primary={false}>
-              <Home path='/' />
-              <Docs path='/docs' />
-              <CookiesPage path='/cookies-policy' />
-              <ThankYou path='/thankyou' />
-              <PageNotFound path='*' />
-              <AboutPage path='/about' />
-              <TeamPage path='/team' />
-              <Cheatsheet path='/cheatsheet' />
+            <Home path='/' />
+            <Docs path='/docs' />
+            <CookiesPage path='/cookies-policy' />
+            <ThankYou path='/thankyou' />
+            <PageNotFound path='*' />
+            <AboutPage path='/about' />
+            <TeamPage path='/team' />
+            <Cheatsheet path='/cheatsheet' />
           </Router>
           <ScrollToTopBtn />
         </div>

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -137,7 +137,7 @@ const IconsSet = (props) => {
         tab === 'Static Icons'
           ? 'TOGGLE_SEARCH_REGULAR_ICONS'
           : 'TOGGLE_SEARCH_ANIMATED_ICONS',
-      search: ''
+      search: selectMultiple ? searchValue : ''
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, dispatch, selectMultiple])
@@ -166,7 +166,7 @@ const IconsSet = (props) => {
   const setTagInSearch = () => {
     return dispatch({
       type: 'TOGGLE_SEARCH_REGULAR_ICONS',
-      search: ''
+      search: urlTagName
     })
   }
 
@@ -209,7 +209,7 @@ const IconsSet = (props) => {
         tab === 'Static Icons'
           ? 'TOGGLE_SEARCH_REGULAR_ICONS'
           : 'TOGGLE_SEARCH_ANIMATED_ICONS',
-      search: ''
+      search: suggestedString
     })
     setSearchValue(suggestedString)
   }

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -28,13 +28,13 @@ const IconsSet = (props) => {
   const [selectMultiple, setSelectMultiple] = useState(true)
   const [emptySearchResult, setEmptySearchResult] = useState(false)
   const [suggestedString, setSuggestedString] = useState('')
- 
-  const activeIconRef = useRef(null) 
-  useEffect(()=> {
-    if(iconSelected!=='') {
-      window.addEventListener('DOMContentLoaded', ()=> {
-        window.scrollTo(0, activeIconRef.current.offsetTop);
-      });
+
+  const activeIconRef = useRef(null)
+  useEffect(() => {
+    if (iconSelected !== '') {
+      window.addEventListener('DOMContentLoaded', () => {
+        window.scrollTo(0, activeIconRef.current.offsetTop)
+      })
     }
   })
 
@@ -439,9 +439,9 @@ const IconsSet = (props) => {
               return categoryObject.icons.length > 0 ? (
                 <div key={index}>
                   <h4 className='category'>{categoryObject.category}</h4>
-                  <div className='icons-list'>  
-                    {categoryObject.icons.map((icon, i) => (
-                      isActive(icon.name,state) ? (
+                  <div className='icons-list'>
+                    {categoryObject.icons.map((icon, i) =>
+                      isActive(icon.name, state) ? (
                         <div ref={activeIconRef}>
                           <Icon
                             size={36}
@@ -453,7 +453,9 @@ const IconsSet = (props) => {
                               selectIcon(
                                 icon,
                                 dispatch({
-                                  type: state.customize ? 'ADD_MULTIPLE_ICONS' : '',
+                                  type: state.customize
+                                    ? 'ADD_MULTIPLE_ICONS'
+                                    : '',
                                   selection: icon.name
                                 })
                               )
@@ -471,14 +473,16 @@ const IconsSet = (props) => {
                             selectIcon(
                               icon,
                               dispatch({
-                                type: state.customize ? 'ADD_MULTIPLE_ICONS' : '',
+                                type: state.customize
+                                  ? 'ADD_MULTIPLE_ICONS'
+                                  : '',
                                 selection: icon.name
                               })
                             )
                           }
                         />
                       )
-                    ))}
+                    )}
                   </div>
                 </div>
               ) : (

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -28,6 +28,15 @@ const IconsSet = (props) => {
   const [selectMultiple, setSelectMultiple] = useState(true)
   const [emptySearchResult, setEmptySearchResult] = useState(false)
   const [suggestedString, setSuggestedString] = useState('')
+ 
+  const activeIconRef = useRef(null) 
+  useEffect(()=> {
+    if(iconSelected!=='') {
+      window.addEventListener('DOMContentLoaded', ()=> {
+        window.scrollTo(0, activeIconRef.current.offsetTop);
+      });
+    }
+  })
 
   let setSearchWithUrlParam = urlIconName
 
@@ -128,7 +137,7 @@ const IconsSet = (props) => {
         tab === 'Static Icons'
           ? 'TOGGLE_SEARCH_REGULAR_ICONS'
           : 'TOGGLE_SEARCH_ANIMATED_ICONS',
-      search: selectMultiple ? searchValue : ''
+      search: ''
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, dispatch, selectMultiple])
@@ -150,14 +159,14 @@ const IconsSet = (props) => {
   const setIconInSearch = () => {
     return dispatch({
       type: 'TOGGLE_SEARCH_REGULAR_ICONS',
-      search: urlIconName
+      search: ''
     })
   }
 
   const setTagInSearch = () => {
     return dispatch({
       type: 'TOGGLE_SEARCH_REGULAR_ICONS',
-      search: urlTagName
+      search: ''
     })
   }
 
@@ -200,7 +209,7 @@ const IconsSet = (props) => {
         tab === 'Static Icons'
           ? 'TOGGLE_SEARCH_REGULAR_ICONS'
           : 'TOGGLE_SEARCH_ANIMATED_ICONS',
-      search: suggestedString
+      search: ''
     })
     setSearchValue(suggestedString)
   }
@@ -430,24 +439,45 @@ const IconsSet = (props) => {
               return categoryObject.icons.length > 0 ? (
                 <div key={index}>
                   <h4 className='category'>{categoryObject.category}</h4>
-                  <div className='icons-list'>
+                  <div className='icons-list'>  
                     {categoryObject.icons.map((icon, i) => (
-                      <Icon
-                        size={36}
-                        active={isActive(icon.name, state)}
-                        key={icon.name}
-                        name={icon.name}
-                        iconsTheme={state.iconsTheme}
-                        action={() =>
-                          selectIcon(
-                            icon,
-                            dispatch({
-                              type: state.customize ? 'ADD_MULTIPLE_ICONS' : '',
-                              selection: icon.name
-                            })
-                          )
-                        }
-                      />
+                      isActive(icon.name,state) ? (
+                        <div ref={activeIconRef}>
+                          <Icon
+                            size={36}
+                            active={isActive(icon.name, state)}
+                            key={icon.name}
+                            name={icon.name}
+                            iconsTheme={state.iconsTheme}
+                            action={() =>
+                              selectIcon(
+                                icon,
+                                dispatch({
+                                  type: state.customize ? 'ADD_MULTIPLE_ICONS' : '',
+                                  selection: icon.name
+                                })
+                              )
+                            }
+                          />
+                        </div>
+                      ) : (
+                        <Icon
+                          size={36}
+                          active={isActive(icon.name, state)}
+                          key={icon.name}
+                          name={icon.name}
+                          iconsTheme={state.iconsTheme}
+                          action={() =>
+                            selectIcon(
+                              icon,
+                              dispatch({
+                                type: state.customize ? 'ADD_MULTIPLE_ICONS' : '',
+                                selection: icon.name
+                              })
+                            )
+                          }
+                        />
+                      )
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
Fixed issues mentioned in Issue #16. On refreshing the page selected Icon doesn't get lost and the selected Icon persists after Page refresh. Whenever a user opens a shared link of an icon the page auto scrolls to the shared icon and highlights the shared Icon as a selection.
I have tested all the scenarios by picking Icons from the top, middle and bottom and also from different categories.
To better illustrate the behavior a video has been attached testing all the scenarios.

https://user-images.githubusercontent.com/55888723/151445028-5563cf8b-5d01-4e14-b62d-e00cd7dde1f8.mp4

