### PR TITLE
Fixed link and image responsiveness issues

### DIFF
--- a/src/assets/scss/pages/docs.scss
+++ b/src/assets/scss/pages/docs.scss
@@ -40,3 +40,13 @@
     }
   }
 }
+
+@media (max-width: 1024px) {
+  .resp-link-edit {
+    overflow: scroll;
+  }
+
+  .onyour-img-edit {
+    width: 100%;
+  }
+}

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -16,7 +16,7 @@ const Docs = () => {
   return (
     <div className='docs'>
       <Helmet>
-        <title>Get EOS Icons | EOS Icons</title>
+        <title>Get EOS Icons | EOS Icons </title>
         <meta
           name='description'
           content='Download the latest copy of our computer-specific icon files for your design or install them in your application using npm, our CDN or our Rails gem.'
@@ -83,8 +83,8 @@ const Docs = () => {
                   <i className='eos-icons eos-18'>open_in_new</i>
                 </a>
               </h3>
-              <p>
-                Default theme (filled):
+              <p>Default theme (filled): </p>
+              <div className='resp-link-edit'>
                 <a
                   href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css'
                   data-event-category='External link'
@@ -96,8 +96,10 @@ const Docs = () => {
                   {' '}
                   https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css
                 </a>
-                <br />
-                Outline theme:
+              </div>
+              <br />
+              <p>Outline theme:</p>
+              <div className='resp-link-edit'>
                 <a
                   href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css'
                   data-event-category='External link'
@@ -109,7 +111,8 @@ const Docs = () => {
                   {' '}
                   https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css
                 </a>
-              </p>
+              </div>
+
               <p>
                 Add one of the following lines in your{' '}
                 <code> &lt;head&gt;</code> tag as <code> link:css </code>
@@ -357,7 +360,7 @@ const Docs = () => {
                 font-file formats. You can also download them individually from
                 here:
               </p>
-              <div>
+              <div className='resp-link-edit'>
                 <table className='table'>
                   <thead>
                     <tr>
@@ -433,6 +436,7 @@ const Docs = () => {
               <img
                 src={FontbookImg}
                 alt='Animation displaying how to install the eos-icons font'
+                className='onyour-img-edit'
               />
               <h2>Using EOS icons in your favourite design tool</h2>
               <p>
@@ -446,6 +450,7 @@ const Docs = () => {
               <img
                 src={UsingIconsImg}
                 alt='Animation displaying how to use eos icons in design tool'
+                className='onyour-img-edit'
               />
             </div>
           </div>
@@ -523,7 +528,7 @@ function App() {
 export default App;`}</code>
               </pre>
               <h2>Props</h2>
-              <div>
+              <div className='resp-link-edit'>
                 <table className='table'>
                   <thead>
                     <tr>

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -112,7 +112,6 @@ const Docs = () => {
                   https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css
                 </a>
               </div>
-
               <p>
                 Add one of the following lines in your{' '}
                 <code> &lt;head&gt;</code> tag as <code> link:css </code>


### PR DESCRIPTION
Fixed #28   
I have added responsiveness to the links and images which were creating the issues. in the mobile view of the eos-landing-page.
Before : - 
![1](https://user-images.githubusercontent.com/67755381/152436550-a9442947-b867-437d-a5f9-db967696e7a4.jpg)
![2](https://user-images.githubusercontent.com/67755381/152436556-3a5e87d1-bb4d-4136-bffc-1868181da6be.jpg)
![3](https://user-images.githubusercontent.com/67755381/152436557-707e8a3a-e3f6-42f4-a5da-6539c79f4acf.jpg)
After :- 
![ch1](https://user-images.githubusercontent.com/67755381/152436864-f7bfdfd7-0079-444c-b5ea-f17e5fad9f88.jpg)
![ch2](https://user-images.githubusercontent.com/67755381/152436870-df5543da-b812-4f3f-b004-746fcadd6921.jpg)
![ch3](https://user-images.githubusercontent.com/67755381/152436872-f2c773f8-b353-4748-afd1-32ef7f05d60c.jpg)
