### PR TITLE
fix: use template json for pr tests

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -37,7 +37,5 @@ jobs:
 
       - name: Test build
         run: |
-          echo $CONFIG_JSON > src/config.json
+          cp src/config.example.json src/config.json
           npm run build
-        env:
-          CONFIG_JSON: src/config.example.json

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -40,4 +40,4 @@ jobs:
           echo $CONFIG_JSON > src/config.json
           npm run build
         env:
-          CONFIG_JSON: ${{ secrets.CONFIG_JSON }}
+          CONFIG_JSON: src/config.example.json


### PR DESCRIPTION
`pr-test` pipeline has been failing because contributors don't have `$CONFIG_JSON` in their secrets. We should use dummy config as it just tests the build.