### PR TITLE
Fixed #39  Added a copy button to the required codes in the docs section

### DIFF
--- a/src/assets/scss/pages/docs.scss
+++ b/src/assets/scss/pages/docs.scss
@@ -39,4 +39,10 @@
       display: inline;
     }
   }
+
+
+  .code-style {
+    display: inline-block;
+  }
+
 }

--- a/src/components/HowToPanel.js
+++ b/src/components/HowToPanel.js
@@ -3,10 +3,11 @@ import AppContext from '../utils/AppContext'
 import Button from './Button'
 import IconEditor from './IconEditor'
 
+import copyToClipboard from '../utils/copyToClipboard'
+
 const HowToPanel = (props) => {
   const { show, close, iconName, type, iconTags } = props
   const ref = useRef()
-
   const [iconEditor, setIconEditor] = useState(false)
   const [iconType, setIconType] = useState('static')
   const iconEditorToggle = (type) => {
@@ -71,7 +72,6 @@ const HowToPanel = (props) => {
     <div ref={ref} className='how-to-use-block'>
       <div className='container'>
         <span>How to use it:</span>
-
         <i className='close-button eos-icons eos-18' onClick={() => close()}>
           close
         </i>
@@ -88,10 +88,7 @@ const HowToPanel = (props) => {
                 />
                 <Button
                   type='button'
-                  onClick={() => {
-                    document.getElementById('copy-code').select()
-                    document.execCommand('copy')
-                  }}
+                  onClick={() => copyToClipboard('copy-code')}
                 >
                   <i className='eos-icons eos-18'>content_copy</i>
                 </Button>
@@ -131,10 +128,7 @@ const HowToPanel = (props) => {
                 />
                 <Button
                   type='button'
-                  onClick={() => {
-                    document.getElementById('copy-code').select()
-                    document.execCommand('copy')
-                  }}
+                  onClick={() => copyToClipboard('copy-code')}
                 >
                   <i className='eos-icons eos-18'>content_copy</i>
                 </Button>

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -8,7 +8,7 @@ import { Link } from '@reach/router'
 import DownloadEOSicons from '../components/DownloadEOSicons'
 import { Helmet } from 'react-helmet'
 import scrollToTop from '../utils/scrollToTop'
-import linkData from '../utils/linksData'
+import copyToClipboard from '../utils/copyToClipboard'
 
 const Docs = () => {
   useEffect(() => {
@@ -27,25 +27,6 @@ const Docs = () => {
       })
     }
   })
-
-  const copyToClipboard = async (value) => {
-    let copyText
-    linkData.map((val) => {
-      if (val.classname === value) {
-        copyText = val.link
-      }
-      return null
-    })
-
-    await navigator.clipboard
-      .writeText(copyText)
-      .then(() => {
-        alert('Successfully Copied')
-      })
-      .catch(() => {
-        alert("Couldn't Copy")
-      })
-  }
 
   return (
     <div className='docs'>
@@ -69,9 +50,9 @@ const Docs = () => {
               Download the latest copy of our computer-specific files. You’ll
               need them to be able to work with your desired design software.
             </p>
-
-            <DownloadEOSicons />
           </div>
+          <br />
+          <DownloadEOSicons />
         </div>
       </PageHeader>
 
@@ -101,7 +82,7 @@ const Docs = () => {
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code className='copytext1 code-style'>
+                <code id='copy-code' className=' code-style'>
                   npm install eos-icons --save
                 </code>
                 <i

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -8,6 +8,7 @@ import { Link } from '@reach/router'
 import DownloadEOSicons from '../components/DownloadEOSicons'
 import { Helmet } from 'react-helmet'
 import scrollToTop from '../utils/scrollToTop'
+import linkData from '../utils/linksData'
 
 const Docs = () => {
   useEffect(() => {
@@ -26,6 +27,25 @@ const Docs = () => {
       })
     }
   })
+
+  const copyToClipboard = async (value) => {
+    let copyText
+    linkData.map((val) => {
+      if (val.classname === value) {
+        copyText = val.link
+      }
+      return null
+    })
+
+    await navigator.clipboard
+      .writeText(copyText)
+      .then(() => {
+        alert('Successfully Copied')
+      })
+      .catch(() => {
+        alert("Couldn't Copy")
+      })
+  }
 
   return (
     <div className='docs'>
@@ -81,7 +101,16 @@ const Docs = () => {
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>npm install eos-icons --save</code>
+                <code className='copytext1 code-style'>
+                  npm install eos-icons --save
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext1')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3 className='padding-top-xs'>
                 Using the CDN
@@ -131,19 +160,33 @@ const Docs = () => {
               </p>
               <h4>Default theme</h4>
               <pre className='code language-html'>
-                <code>
+                <code className='copytext2 code-style'>
                   {
                     "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css' />"
                   }
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext2')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h4>Outlined theme</h4>
               <pre className='code language-html'>
-                <code>
+                <code className='copytext3 code-style'>
                   {
                     "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css' />"
                   }
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext3')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3 className='padding-top-xs'>
                 Installing the Ruby gem
@@ -160,7 +203,17 @@ const Docs = () => {
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>gem install eos-icons-font</code>
+                <code className='copytext4 code-style'>
+                  gem install eos-icons-font
+                </code>
+
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext4')}
+                >
+                  content_copy
+                </i>
               </pre>
               <p>
                 Add the following directive to your application:{' '}
@@ -181,13 +234,29 @@ const Docs = () => {
                 (*) If you're using the CDN, you can skip this step.
               </p>
               <pre className='code language-html'>
-                <code>{"<link rel='stylesheet' href='eos-icons.css'/>"}</code>
+                <code className='copytext5 code-style'>
+                  {"<link rel='stylesheet' href='eos-icons.css'/>"}
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext5')}
+                >
+                  content_copy
+                </i>
               </pre>
               or
               <pre className='code language-html'>
-                <code>
+                <code className='copytext6 code-style'>
                   {"<link rel='stylesheet' href='eos-icons-outlined.css'/>"}
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext6')}
+                >
+                  content_copy
+                </i>
               </pre>
               <p>
                 2- Make sure the fonts folder available at{' '}
@@ -205,13 +274,29 @@ const Docs = () => {
               </code>
               <p>3- Use the icons in your html as follows:</p>
               <pre className='code language-html'>
-                <code>{"<i class='eos-icons'>LIGATURE_OF_THE_ICON</i>"}</code>
+                <code className='copytext7 code-style'>
+                  {"<i class='eos-icons'>LIGATURE_OF_THE_ICON</i>"}
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext7')}
+                >
+                  content_copy
+                </i>
               </pre>
               or for outlined icons
               <pre className='code language-html'>
-                <code>
+                <code className='copytext8 code-style'>
                   {"<i class='eos-icons-outlined'>LIGATURE_OF_THE_ICON</i>"}
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext8')}
+                >
+                  content_copy
+                </i>
               </pre>
               <p>
                 Where the <code>LIGATURE_OF_THE_ICON</code> is the name of the
@@ -237,7 +322,16 @@ const Docs = () => {
                 example:
               </p>
               <pre className='code language-html'>
-                <code>{"<img src='loading'/>"}</code>
+                <code className='copytext9 code-style'>
+                  {"<img src='loading'/>"}
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext9')}
+                >
+                  content_copy
+                </i>
               </pre>
               <p>
                 Head to the
@@ -267,16 +361,23 @@ const Docs = () => {
               <i className='eos-icons eos-36 mr-3'>miscellaneous</i>
               <i className='eos-icons eos-48'>miscellaneous</i>
               <pre className='code language-html'>
-                <code>
+                <code className='copytext10 code-style'>
                   {`<i class='eos-icons eos-18'>miscellaneous</i>
   <i class='eos-icons eos-24'>miscellaneous</i>
   <i class='eos-icons eos-36'>miscellaneous</i>
   <i class='eos-icons eos-48'>miscellaneous</i> `}
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext10')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h4>SCSS code snippet</h4>
               <pre className='code language-css'>
-                <code>
+                <code className='copytext11 code-style'>
                   {`/* size variables */
   $eos-18: 18px;
   $eos-24: 24px;
@@ -289,6 +390,13 @@ const Docs = () => {
   .eos-36 { font-size: $eos-36; }
   .eos-48 { font-size: $eos-48; } `}
                 </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext11')}
+                >
+                  content_copy
+                </i>
               </pre>
               <p>
                 EOS icons is open source. Go to our Gitlab repository to find
@@ -485,7 +593,16 @@ const Docs = () => {
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>npm install eos-icons-react</code>
+                <code className='copytext12 code-style'>
+                  npm install eos-icons-react
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext12')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3 className='padding-top-xs'>
                 Installation with yarn
@@ -502,13 +619,22 @@ const Docs = () => {
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>yarn add eos-icons-react</code>
+                <code className='copytext13 code-style'>
+                  yarn add eos-icons-react
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext13')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Using EOS icons React in your projects</h2>
               Note: the middle part of the component name is the same as the
               icon name and should always be written in uppercase.
               <pre className='code language-js'>
-                <code>{`import { EOS_STAR, EOS_STAR_FILLED, EOS_STAR_OUTLINED } from 'eos-icons-react';
+                <code className='copytext14 code-style'>{`import { EOS_STAR, EOS_STAR_FILLED, EOS_STAR_OUTLINED } from 'eos-icons-react';
 
 function App() {
   return (
@@ -521,11 +647,19 @@ function App() {
 }
 
 export default App;`}</code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext14')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Using Animated icons</h2>
               <pre className='code language-js'>
-                <code>{`import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
-
+                <code className='copytext15 code-style'>{`import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
+                
+                
 function App() {
   return (
     <div>
@@ -535,6 +669,13 @@ function App() {
 }
 
 export default App;`}</code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext15')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Props</h2>
               <div>
@@ -717,7 +858,16 @@ export default App;`}</code>
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>npm install eos-icons-vue3</code>
+                <code className='copytext16 code-style'>
+                  npm install eos-icons-vue3
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext16')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3 className='padding-top-xs'>
                 Installation with yarn
@@ -734,7 +884,16 @@ export default App;`}</code>
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>yarn add eos-icons-vue3</code>
+                <code className='copytext17 code-style'>
+                  yarn add eos-icons-vue3
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext17')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Installing EOS icons for Vue 2</h2>
               <h3 className='padding-top-xs'>
@@ -752,7 +911,16 @@ export default App;`}</code>
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>npm install eos-icons-vue2</code>
+                <code className='copytext18 code-style'>
+                  npm install eos-icons-vue2
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext18')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3 className='padding-top-xs'>
                 Installation with yarn
@@ -769,14 +937,23 @@ export default App;`}</code>
                 </a>
               </h3>
               <pre className='code language-shell'>
-                <code>yarn add eos-icons-vue2</code>
+                <code className='copytext19 code-style'>
+                  yarn add eos-icons-vue2
+                </code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext19')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Using EOS icons Vue in your projects</h2>
               Note: the middle part of the component name is the same as the
               icon name and should always be written in uppercase.
               <h3>Vue 3 usage:</h3>
               <pre className='code language-js'>
-                <code>{`<template>
+                <code className='copytext20 code-style'>{`<template>
   <div>
     <EOS_10K_FILLED />
     <EOS_10K_OUTLINED />
@@ -796,10 +973,17 @@ export default {
   },
 };
 </script>`}</code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext20')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h3>Vue 2 usage:</h3>
               <pre className='code language-js'>
-                <code>{`<template>
+                <code className='copytext21 code-style'>{`<template>
   <div>
     <EOS_10K_FILLED />
     <EOS_10K_OUTLINED />
@@ -819,6 +1003,13 @@ export default {
   },
 };
 </script>`}</code>
+                <i
+                  class='eos-icons'
+                  style={{ cursor: 'pointer', float: 'right' }}
+                  onClick={() => copyToClipboard('.copytext21')}
+                >
+                  content_copy
+                </i>
               </pre>
               <h2>Props</h2>
               <div>

--- a/src/pages/TeamPage.jsx
+++ b/src/pages/TeamPage.jsx
@@ -70,9 +70,7 @@ export const TeamPage = () => {
 
         <div className='team-page-cta'>
           <div className='slack-cta'>
-            <h4 style={{ textAlign: 'center' }}>
-              Join us, become a contributor!
-            </h4>
+            <h2>Join us, become a contributor!</h2>
 
             <p>
               Be part of the team, join our Slack channel, and chat with our

--- a/src/pages/TeamPage.jsx
+++ b/src/pages/TeamPage.jsx
@@ -70,7 +70,9 @@ export const TeamPage = () => {
 
         <div className='team-page-cta'>
           <div className='slack-cta'>
-            <h4>Join us, become a contributor!</h4>
+            <h4 style={{ textAlign: 'center' }}>
+              Join us, become a contributor!
+            </h4>
 
             <p>
               Be part of the team, join our Slack channel, and chat with our

--- a/src/utils/copyToClipboard.js
+++ b/src/utils/copyToClipboard.js
@@ -1,0 +1,28 @@
+import linkData from './linksData'
+
+const copyToClipboard = async (value) => {
+  if (value === 'copy-code') {
+    document.getElementById('copy-code').select()
+    document.execCommand('copy')
+    alert('Successfully Copied')
+  } else {
+    let copyText
+    linkData.map((val) => {
+      if (val.classname === value) {
+        copyText = val.link
+      }
+      return null
+    })
+
+    await navigator.clipboard
+      .writeText(copyText)
+      .then(() => {
+        alert('Successfully Copied')
+      })
+      .catch(() => {
+        alert("Couldn't Copy")
+      })
+  }
+}
+
+export default copyToClipboard

--- a/src/utils/linksData.js
+++ b/src/utils/linksData.js
@@ -1,0 +1,96 @@
+const LinkData = [
+  {
+    classname: '.copytext1',
+    link: 'npm install eos-icons --save'
+  },
+  {
+    classname: '.copytext2',
+    link:
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css' />"
+  },
+  {
+    classname: '.copytext3',
+    link:
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css' />"
+  },
+  {
+    classname: '.copytext4',
+    link: 'gem install eos-icons-font'
+  },
+  {
+    classname: '.copytext5',
+    link: "<link rel='stylesheet' href='eos-icons.css'/>"
+  },
+  {
+    classname: '.copytext6',
+    link: "<link rel='stylesheet' href='eos-icons-outlined.css'/>"
+  },
+  {
+    classname: '.copytext7',
+    link: "<i class='eos-icons'>LIGATURE_OF_THE_ICON</i>"
+  },
+  {
+    classname: '.copytext8',
+    link: "<i class='eos-icons-outlined'>LIGATURE_OF_THE_ICON</i>"
+  },
+  {
+    classname: '.copytext9',
+    link: "<img src='loading'/>"
+  },
+  {
+    classname: '.copytext10',
+    link:
+      "<i class='eos-icons eos-18'>miscellaneous</i> <i class='eos-icons eos-24'>miscellaneous</i><i class='eos-icons eos-36'>miscellaneous</i> <i class='eos-icons eos-48'>miscellaneous</i> "
+  },
+  {
+    classname: '.copytext11',
+    link:
+      '/* size variables */ $eos-18: 18px; $eos-24: 24px; $eos-36: 36px; $eos-48: 48px; /* Rules for sizing the icon. */ .eos-18 { font-size: $eos-18; } .eos-24 { font-size: $eos-24; } .eos-36 font-size: $eos-36; } .eos-48 { font-size: $eos-48; }'
+  },
+  {
+    classname: '.copytext12',
+    link: 'npm install eos-icons-react'
+  },
+  {
+    classname: '.copytext13',
+    link: 'yarn add eos-icons-react'
+  },
+  {
+    classname: '.copytext14',
+    link:
+      "import { EOS_STAR, EOS_STAR_FILLED, EOS_STAR_OUTLINED } from 'eos-icons-react'; function App() { return ( <div> <EOS_STAR/> <EOS_STAR_FILLED /> <EOS_STAR_OUTLINED /> </div> ); } export default App;"
+  },
+  {
+    classname: '.copytext15',
+    link:
+      "import { EOS_LOADING_ANIMATED } from 'eos-icons-react'; function App() { return ( <div> <EOS_LOADING_ANIMATED /> </div> );} export default App;"
+  },
+  {
+    classname: '.copytext16',
+    link: 'npm install eos-icons-vue3'
+  },
+  {
+    classname: '.copytext17',
+    link: 'yarn add eos-icons-vue3'
+  },
+  {
+    classname: '.copytext18',
+    link: 'npm install eos-icons-vue2'
+  },
+  {
+    classname: '.copytext19',
+    link: 'yarn add eos-icons-vue2'
+  },
+  {
+    classname: '.copytext20',
+    link:
+      '<template> <div> <EOS_10K_FILLED /> <EOS_10K_OUTLINED /> <EOS_LOADING_ANIMATED /> </div> </template> <script> import { EOS_10K_FILLED, EOS_10K_OUTLINED, EOS_LOADING_ANIMATED } from "eos-icons-vue3"; export default { name: "App", components: { EOS_10K_FILLED, EOS_10K_OUTLINED, EOS_LOADING_ANIMATED }, 0}; </script>'
+  },
+  {
+    classname: '.copytext21',
+    link:
+      '<template> <div> <EOS_10K_FILLED /> <EOS_10K_OUTLINED /> <EOS_LOADING_ANIMATED /> </div> </template> <script> import { EOS_10K_FILLED, EOS_10K_OUTLINED, EOS_LOADING_ANIMATED } from "eos-icons-vue2"; export default { name: "App", components: { EOS_10K_FILLED, EOS_10K_OUTLINED, EOS_LOADING_ANIMATED }, }; </script>'
+  }
+]
+
+export default LinkData


### PR DESCRIPTION
Fixes #39 
I have added copy button (copy icon basically imported from the eos-library) working as a button. 
When a user clicks on the icon it copies the text written in the code section.
I have to create a separate file named as linksData.js which keeps all the links available on the docs page and I have mapped them to copy. 