### PR TITLE
Fixed #6 & #40: No result found screen & search Value is not empty on tab change

### DIFF
--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -121,14 +121,8 @@ const IconsSet = (props) => {
   }, [emptySearchResult, tab, searchValue])
 
   useEffect(() => {
-    if (tab === 'Static Icons') {
-      window.history.replaceState(
-        '',
-        'EOS Icons',
-        `${window.location.pathname}`
-      )
-      setSearchValue('')
-    }
+    window.history.replaceState('', 'EOS Icons', `${window.location.pathname}`)
+    setSearchValue('')
     const count = getSearchResults(searchValue)
 
     if (count === 0) {
@@ -264,9 +258,7 @@ const IconsSet = (props) => {
 
   /* Function to close HowToPanel upon switching tabs */
   const tabSwitch = (e) => {
-    if (e === tab) {
-      setActiveTab(e)
-    } else {
+    if (e !== tab) {
       setActiveTab(e)
       if (e === 'Static Icons') {
         setAnimatedHistory(iconSelected)
@@ -538,7 +530,7 @@ const IconsSet = (props) => {
             })}
           </div>
           <div label='Animated Icons'>
-            {emptySearchResult && (
+            {searchValue !== '' && emptySearchResult && (
               <div>
                 <h3 className='suggested-search-line'>
                   Did you mean{' '}


### PR DESCRIPTION
fixes: #6 
fixes: #40  

1. On tab change from static to animated search value is not getting emptied as earlier it happens to get emptied when the active tab is static but search value should be emptied irrespective of the active tab

2. No result found screen should only be shown when a user had searched for any icon & there are no results for that icon present.



https://user-images.githubusercontent.com/44670961/153842917-cd40d6ca-a9f4-4e58-a583-7193f810b6c8.mp4

Signed-off-by: chinmaym07 <b418020@iiit-bh.ac.in>