### PR TITLE
Updated Contrast for search categories and updated h2 links from lighter to bolder.

### DIFF
--- a/src/assets/scss/base/titles.scss
+++ b/src/assets/scss/base/titles.scss
@@ -10,7 +10,7 @@ h6 {
 
 h1,
 h2 {
-  font-weight: $font-weight;
+  font-weight: bolder;
   line-height: 1.5em;
   margin: 0;
 }

--- a/src/assets/scss/components/badge.scss
+++ b/src/assets/scss/components/badge.scss
@@ -1,5 +1,5 @@
 .badge {
-  background-color: $lightest-gray;
+  background-color: $dark-gray;
   border-radius: 100px;
   color: $white;
   display: inline-block;


### PR DESCRIPTION
Fixed #11 As discussed with cynthia I have updated the contrast  for Search Categories and Updated the h2 links from lighter to bolder for better contrast view which now passes the check.
![pass](https://user-images.githubusercontent.com/67755381/155390740-ea82aee4-b77a-4f93-ba7f-af9e532d2a46.jpg)
