### PR TITLE
fix links in the Footer

### DIFF
--- a/src/utils/Links.store.js
+++ b/src/utils/Links.store.js
@@ -20,7 +20,7 @@ export default [
       },
       {
         name: 'Repository',
-        href: 'https://gitlab.com/SUSE-UIUX/eos-icons',
+        href: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing',
         category: 'External link',
         action: 'Link to Gitlab repo',
         label: 'Footer',
@@ -28,7 +28,7 @@ export default [
       },
       {
         name: 'Report an issue',
-        href: 'https://gitlab.com/SUSE-UIUX/eos-icons/issues',
+        href: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing/issues',
         category: 'External link',
         action: 'Link to Gitlab issues',
         label: 'Footer',

--- a/src/utils/Links.store.js
+++ b/src/utils/Links.store.js
@@ -22,7 +22,7 @@ export default [
         name: 'Repository',
         href: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing',
         category: 'External link',
-        action: 'Link to Gitlab repo',
+        action: 'Link to Github repo',
         label: 'Footer',
         target: '_blank'
       },
@@ -30,7 +30,7 @@ export default [
         name: 'Report an issue',
         href: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing/issues',
         category: 'External link',
-        action: 'Link to Gitlab issues',
+        action: 'Link to Github issues',
         label: 'Footer',
         target: '_blank'
       }


### PR DESCRIPTION
Fixes #75 . Updated "Repository" and "Report an issue" Links in the Footer from GitLab to Github links. 