### PR TITLE
Shifting links from gitlab to github in Docs and About Us Pages

### DIFF
--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -49,7 +49,7 @@ const data = [
     title: 'Open Source',
     description:
       'Commercial, non-commercial, use them as you please. EOS icons comes with an MIT license, has an open source community, and welcomes your collaboration too.',
-    linkTo: 'https://gitlab.com/SUSE-UIUX/eos-icons/',
+    linkTo: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing',
     linkTitle: 'View the git repository ',
     image: require('../assets/images/pages/open-source.png'),
     reverse: false

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -294,19 +294,19 @@ const Docs = () => {
                 </code>
               </pre>
               <p>
-                EOS icons is open source. Go to our Gitlab repository to find
+                EOS icons is open source. Go to our Github repository to find
                 out more :
                 <a
-                  href='https://gitlab.com/SUSE-UIUX/eos-icons'
+                  href='https://github.com/EOS-uiux-Solutions/eos-icons-landing'
                   data-event-category='External link'
-                  data-event-action='Link to Gitlab repository'
+                  data-event-action='Link to Github repository'
                   data-event-label='Docs page'
                   target='_blank'
                   rel='noopener noreferrer'
                   className='line-edit'
                 >
                   {' '}
-                  https://gitlab.com/SUSE-UIUX/eos-icons
+                  https://github.com/EOS-uiux-Solutions/eos-icons-landing
                 </a>
               </p>
             </div>


### PR DESCRIPTION
Shifting links from Gitlab to Github in About Us and Docs Pages

About us 
![image](https://user-images.githubusercontent.com/55888723/156926893-3c9b8270-d4c6-4df3-8ce0-8a9702176622.png)

Docs

![image](https://user-images.githubusercontent.com/55888723/156926944-36aea493-ccba-44ec-8544-646c7fb09dd4.png)
