### PR TITLE
Fixed broken gitlab links in Docs and About Us Pages

### DIFF
--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -49,7 +49,7 @@ const data = [
     title: 'Open Source',
     description:
       'Commercial, non-commercial, use them as you please. EOS icons comes with an MIT license, has an open source community, and welcomes your collaboration too.',
-    linkTo: 'https://gitlab.com/SUSE-UIUX/eos-icons/',
+    linkTo: 'https://github.com/EOS-uiux-Solutions/eos-icons-landing',
     linkTitle: 'View the git repository ',
     image: require('../assets/images/pages/open-source.png'),
     reverse: false

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -294,19 +294,19 @@ const Docs = () => {
                 </code>
               </pre>
               <p>
-                EOS icons is open source. Go to our Gitlab repository to find
+                EOS icons is open source. Go to our Github repository to find
                 out more :
                 <a
-                  href='https://gitlab.com/SUSE-UIUX/eos-icons'
+                  href='https://github.com/EOS-uiux-Solutions/eos-icons-landing'
                   data-event-category='External link'
-                  data-event-action='Link to Gitlab repository'
+                  data-event-action='Link to Github repository'
                   data-event-label='Docs page'
                   target='_blank'
                   rel='noopener noreferrer'
                   className='line-edit'
                 >
                   {' '}
-                  https://gitlab.com/SUSE-UIUX/eos-icons
+                  https://github.com/EOS-uiux-Solutions/eos-icons-landing
                 </a>
               </p>
             </div>


### PR DESCRIPTION
This PR replaces old Gitlab links with new Github links in About Us and Docs Pages.

About Us

![image](https://user-images.githubusercontent.com/55888723/156978568-2b0df7a7-53b3-4555-9156-86b37924a66c.png)

Docs

![image](https://user-images.githubusercontent.com/55888723/156978629-8a9d9072-479d-4376-b294-88047fc55826.png)
