### PR TITLE
fix default behaviour on clicking navbar logo

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -17,11 +17,11 @@ const Navigation = () => {
   return (
     <header className='flex-wrap-sm navigation'>
       <div className='container navigation-content'>
-        <Link to='/'>
+        <a href='/'>
           <div className='brand'>
             <img className='logo' src={eosIcon} alt='eos-icons logo' />
           </div>
-        </Link>
+        </a>
         <nav className='padding-top-xs'>
           <NavLink to='/'>
             <i className='eos-icons'>miscellaneous</i>


### PR DESCRIPTION
Fixes #80. 
I have replaced the router Link with an anchor tag forcing the page to hard reload clearing all the states and restoring the original view.
Hers is a sample video showing the current behavior.


https://user-images.githubusercontent.com/55888723/157175974-1cb40847-a952-4da2-b76a-7980bd70eeb7.mp4


