### PR TITLE
fixed last active icon selected on switching select multiple icons

### DIFF
--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -251,7 +251,11 @@ const IconsSet = (props) => {
 
   /* Toggle customizable functionality */
   const toggleCustomize = (callback) => {
+    setShowPanel(false)
+    setSearchValue('')
+    setIconSelected('')
     setSelectMultiple(!selectMultiple)
+    window.history.replaceState('', 'EOS Icons', `${window.location.pathname}`)
     props.action()
     return callback
   }


### PR DESCRIPTION
Fixes #57 
Clearing the last selected icon which is shown as a selected icon when the Select Multiple button is toggled. We aim to clear URL params, howToUse section, and the last selected icon.

Here is a preview of how the changes look and feel.

https://user-images.githubusercontent.com/55888723/157505648-86b4deff-d00b-496a-98ff-82d1d8df23a9.mp4


