### PR TITLE
fix unusual behaviour on deselecting an icon

### DIFF
--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -239,6 +239,7 @@ const IconsSet = (props) => {
   const selectIcon = (icon, callback) => {
     setShowPanel(icon !== iconSelected)
     setIconSelected(icon === iconSelected ? '' : icon)
+    setSearchValue(icon.name === searchValue ? '' : icon.name)
     if (selectMultiple) {
       window.history.replaceState(
         '',

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -239,7 +239,9 @@ const IconsSet = (props) => {
   const selectIcon = (icon, callback) => {
     setShowPanel(icon !== iconSelected)
     setIconSelected(icon === iconSelected ? '' : icon)
-    setSearchValue(icon.name === searchValue ? '' : icon.name)
+    setSearchValue((searchValue) =>
+      icon.name === searchValue ? '' : icon.name
+    )
     if (selectMultiple) {
       window.history.replaceState(
         '',


### PR DESCRIPTION
Fixes #82. Earlier, for deselecting an icon it took double clicks and the search and URL params didn't get cleared. A video is attached below to show the current behavior after fixing the issue.

https://user-images.githubusercontent.com/55888723/157908533-26efc1a1-3925-4b6a-a614-aa26704a2f67.mp4


