### PR TITLE
Fixed clickOutside behaviour when colour picker is open

### DIFF
--- a/src/components/IconEditor.js
+++ b/src/components/IconEditor.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useState, useEffect, useContext, useRef } from 'react'
 import { SketchPicker } from 'react-color'
 import Button from './Button'
 import axios from 'axios'
@@ -23,6 +23,21 @@ const IconEditor = (props) => {
   const [svgCode, setSvgCode] = useState([])
   const [svgError, setSvgError] = useState(true)
   const { state } = useContext(AppContext)
+
+  const iconEditorRef = useRef()
+  useEffect(() => {
+    const clickOutsideEventHandler = (event) => {
+      if (!iconEditorRef.current.contains(event.target)) {
+        show()
+      }
+    }
+
+    document.addEventListener('click', clickOutsideEventHandler)
+
+    return () => {
+      document.removeEventListener('click', clickOutsideEventHandler)
+    }
+  }, [show])
 
   const exportSizes = [
     '18',
@@ -174,7 +189,7 @@ const IconEditor = (props) => {
 
   return isActive ? (
     <div className='icon-editor'>
-      <div className='icon-editor-card'>
+      <div className='icon-editor-card' ref={iconEditorRef}>
         <div className='close' onClick={show} />
         <h2>Customize Icon</h2>
         <div className='flex flex-row icon-editor-content'>


### PR DESCRIPTION
Fixes #100. The color picker prompt closes when the user clicks outside the color picker prompt.

Current behavior

https://user-images.githubusercontent.com/55888723/158228926-a4eb5703-8820-438b-99a6-480fefebc9b9.mp4


