### PR TITLE
Smoothen current color picker cursor by making it continuous

### DIFF
--- a/src/components/IconEditor.js
+++ b/src/components/IconEditor.js
@@ -184,7 +184,7 @@ const IconEditor = (props) => {
               className='color-picker'
               color={color}
               disableAlpha={true}
-              onChangeComplete={changeColor}
+              onChange={changeColor}
             />
             <br />
             {!svgError && (


### PR DESCRIPTION
Fixes #102. Smoothen color picker cursor by making it continuous for a nice user experience.

Updated behavior 

https://user-images.githubusercontent.com/55888723/158235348-2f8babad-3ab5-4fc7-b0fc-a04d6560d6d6.mp4


