### PR TITLE
Fixed spacing issues in Outlined and Filled icons

### DIFF
--- a/src/assets/scss/components/icon-list.scss
+++ b/src/assets/scss/components/icon-list.scss
@@ -41,6 +41,16 @@
       text-align: center;
       width: 32px;
     }
+
+    .eos-icons-outlined,
+    img {
+      border: 2px solid $white;
+      height: 32px;
+      margin: 10px;
+      padding: 10px;
+      text-align: center;
+      width: 32px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixed #97 The Switch theme icons consisting of Outline and Filled are now positioned correctly when switching as shown.

https://user-images.githubusercontent.com/67755381/158439104-49441d73-ac53-48dd-8513-6b781a9aa41a.mp4

