### PR TITLE
fixed file upload format in Upload JSON button

### DIFF
--- a/src/components/CustomizeIconsPanel.js
+++ b/src/components/CustomizeIconsPanel.js
@@ -92,6 +92,7 @@ const CustomizeIconsPanel = (props) => {
             <input
               type='file'
               id='upload-file'
+              accept='application/JSON'
               hidden
               name='file'
               onChange={(event) => search(event.target.files[0], dispatch)}


### PR DESCRIPTION
Fixes #108. Restricts the upload file format to .json only in the Upload JSON button in Customize Icons Panel.