### PR TITLE
fixing build fail caused by useClickOutside

### DIFF
--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,11 +1,14 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 
 const useClickOutside = (ref, callback) => {
-  const handleClick = (e) => {
-    if (ref.current && !ref.current.contains(e.target)) {
-      callback()
-    }
-  }
+  const handleClick = useCallback(
+    (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback()
+      }
+    },
+    [callback, ref]
+  )
 
   useEffect(() => {
     document.addEventListener('click', handleClick)
@@ -13,7 +16,7 @@ const useClickOutside = (ref, callback) => {
     return () => {
       document.removeEventListener('click', handleClick)
     }
-  }, [])
+  }, [handleClick])
 }
 
 export default useClickOutside


### PR DESCRIPTION
In my recent PR #101, I had created a file useClickOutside. Due to some warnings in that file build is failing for new subsequent PRs. In this PR I have added the fixes so that build runs smoothly and the functionality of #101 remains unhindered.