### PR TITLE
Open icon editor panel on double clicking an icon

### DIFF
--- a/src/components/IconDisplay.js
+++ b/src/components/IconDisplay.js
@@ -1,8 +1,15 @@
 import React from 'react'
 
 const Icon = (props) => {
-  const { name, size, onClickAction, onDoubleClickAction, active, iconsTheme } =
-    props
+  const {
+    name,
+    size,
+    onClickAction,
+    onDoubleClickAction,
+    type,
+    active,
+    iconsTheme
+  } = props
   /* Possible icon sizes */
   const sizes = {
     18: 'eos-18',
@@ -19,7 +26,7 @@ const Icon = (props) => {
     return finalClass
   }
 
-  return (
+  return type === 'static' ? (
     <div
       className={iconClass()}
       onClick={(event) => {
@@ -34,6 +41,17 @@ const Icon = (props) => {
       >
         {name}
       </i>
+      {name}
+    </div>
+  ) : (
+    <div
+      className={iconClass()}
+      onClick={(event) => {
+        if (event.detail === 1) onClickAction()
+        if (event.detail === 2) onDoubleClickAction()
+      }}
+    >
+      <img src={require(`eos-icons/animated-svg/${name}.svg`)} alt={name} />
       {name}
     </div>
   )

--- a/src/components/IconDisplay.js
+++ b/src/components/IconDisplay.js
@@ -1,7 +1,8 @@
 import React from 'react'
 
 const Icon = (props) => {
-  const { name, size, action, active, iconsTheme } = props
+  const { name, size, onClickAction, onDoubleClickAction, active, iconsTheme } =
+    props
   /* Possible icon sizes */
   const sizes = {
     18: 'eos-18',
@@ -19,7 +20,13 @@ const Icon = (props) => {
   }
 
   return (
-    <div className={iconClass()} onClick={action}>
+    <div
+      className={iconClass()}
+      onClick={(event) => {
+        if (event.detail === 1) onClickAction()
+        if (event.detail === 2) onDoubleClickAction()
+      }}
+    >
       <i
         className={`eos-icons${iconsTheme === 'outlined' ? '-outlined' : ' '} ${
           sizes[size]

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -258,6 +258,19 @@ const IconsSet = (props) => {
     return callback
   }
 
+  const selectAnimatedIcon = (icon) => {
+    setIconSelected({ name: icon })
+    setShowPanel(true)
+    setSearchValue(icon)
+    if (selectMultiple) {
+      window.history.replaceState(
+        '',
+        'EOS Icons',
+        `${window.location.pathname}?iconName=${icon}&type=animated`
+      )
+    }
+  }
+
   /* Toggle customizable functionality */
   const toggleCustomize = (callback) => {
     setShowPanel(false)
@@ -506,6 +519,7 @@ const IconsSet = (props) => {
                             key={icon.name}
                             name={icon.name}
                             iconsTheme={state.iconsTheme}
+                            type={'static'}
                             onClickAction={() =>
                               selectIcon(
                                 icon,
@@ -527,6 +541,7 @@ const IconsSet = (props) => {
                           key={icon.name}
                           name={icon.name}
                           iconsTheme={state.iconsTheme}
+                          type={'static'}
                           onClickAction={() =>
                             selectIcon(
                               icon,
@@ -569,33 +584,16 @@ const IconsSet = (props) => {
             )}
             <div className='icons-list'>
               {state.animatedIcons.map((icon, index) => (
-                <div
-                  className={`icon-container ${
-                    icon === iconSelected?.name ? 'active' : ''
-                  }`}
+                <Icon
                   key={index}
-                  onClick={(event) => {
-                    if (event.detail === 1) {
-                      setIconSelected({ name: icon })
-                      setShowPanel(true)
-                      setSearchValue(icon)
-                      if (selectMultiple) {
-                        window.history.replaceState(
-                          '',
-                          'EOS Icons',
-                          `${window.location.pathname}?iconName=${icon}&type=animated`
-                        )
-                      }
-                    }
-                    if (event.detail === 2) iconEditorToggle()
+                  name={icon}
+                  type={'animated'}
+                  active={icon === iconSelected?.name}
+                  onClickAction={() => {
+                    selectAnimatedIcon(icon)
                   }}
-                >
-                  <img
-                    src={require(`eos-icons/animated-svg/${icon}.svg`)}
-                    alt={icon}
-                  />
-                  {icon}
-                </div>
+                  onDoubleClickAction={() => iconEditorToggle()}
+                />
               ))}
             </div>
           </div>

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -10,6 +10,7 @@ import { eosIconsState } from '../utils/EosIcons.store'
 import PageHeader from '../components/PageHeader'
 import { CategorySelector } from '../components/CategorySelector'
 import { useWindowsSize } from '../hooks/useWindow'
+import IconEditor from '../components/IconEditor'
 
 const IconsSet = (props) => {
   const [iconSelected, setIconSelected] = useState('')
@@ -29,6 +30,11 @@ const IconsSet = (props) => {
   const [selectMultiple, setSelectMultiple] = useState(true)
   const [emptySearchResult, setEmptySearchResult] = useState(false)
   const [suggestedString, setSuggestedString] = useState('')
+  const [iconEditor, setIconEditor] = useState(false)
+
+  const iconEditorToggle = () => {
+    setIconEditor(!iconEditor)
+  }
 
   const activeIconRef = useRef(null)
   useEffect(() => {
@@ -500,7 +506,7 @@ const IconsSet = (props) => {
                             key={icon.name}
                             name={icon.name}
                             iconsTheme={state.iconsTheme}
-                            action={() =>
+                            onClickAction={() =>
                               selectIcon(
                                 icon,
                                 dispatch({
@@ -511,6 +517,7 @@ const IconsSet = (props) => {
                                 })
                               )
                             }
+                            onDoubleClickAction={() => iconEditorToggle()}
                           />
                         </div>
                       ) : (
@@ -520,7 +527,7 @@ const IconsSet = (props) => {
                           key={icon.name}
                           name={icon.name}
                           iconsTheme={state.iconsTheme}
-                          action={() =>
+                          onClickAction={() =>
                             selectIcon(
                               icon,
                               dispatch({
@@ -531,6 +538,7 @@ const IconsSet = (props) => {
                               })
                             )
                           }
+                          onDoubleClickAction={() => iconEditorToggle()}
                         />
                       )
                     )}
@@ -566,17 +574,20 @@ const IconsSet = (props) => {
                     icon === iconSelected?.name ? 'active' : ''
                   }`}
                   key={index}
-                  onClick={() => {
-                    setIconSelected({ name: icon })
-                    setShowPanel(true)
-                    setSearchValue(icon)
-                    if (selectMultiple) {
-                      window.history.replaceState(
-                        '',
-                        'EOS Icons',
-                        `${window.location.pathname}?iconName=${icon}&type=animated`
-                      )
+                  onClick={(event) => {
+                    if (event.detail === 1) {
+                      setIconSelected({ name: icon })
+                      setShowPanel(true)
+                      setSearchValue(icon)
+                      if (selectMultiple) {
+                        window.history.replaceState(
+                          '',
+                          'EOS Icons',
+                          `${window.location.pathname}?iconName=${icon}&type=animated`
+                        )
+                      }
                     }
+                    if (event.detail === 2) iconEditorToggle()
                   }}
                 >
                   <img
@@ -589,6 +600,27 @@ const IconsSet = (props) => {
             </div>
           </div>
         </Tabs>
+        {iconEditor ? (
+          tab === 'Static Icons' ? (
+            <IconEditor
+              isActive={iconEditor}
+              show={iconEditorToggle}
+              iconNames={[iconSelected?.name]}
+              iconType={'static'}
+              theme={state.iconsTheme}
+            />
+          ) : (
+            <IconEditor
+              isActive={iconEditor}
+              show={iconEditorToggle}
+              iconNames={[iconSelected?.name]}
+              iconType={'animated'}
+              theme={state.iconsTheme}
+            />
+          )
+        ) : (
+          ''
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
Fixes #118. Enabling functionality for opening icon editor panel on double clicking an icon. Attaching a video showing current behavior. 

https://user-images.githubusercontent.com/55888723/159130982-f50e03a9-5c4e-4fa3-b51b-fb478ddb9dd1.mp4


