### PR TITLE
fixed white space in the docs section #117

### DIFF
--- a/src/assets/scss/layout/general.scss
+++ b/src/assets/scss/layout/general.scss
@@ -13,7 +13,6 @@ body {
 .container {
   margin: auto;
   max-width: 1140px;
-  padding: $xl;
 }
 
 .disabled {


### PR DESCRIPTION
![fixed space](https://user-images.githubusercontent.com/84984600/159140552-f71fe68d-cc36-4526-a792-388dcc3cf729.png)

White space is now fixed under the Docs section