### PR TITLE
fix behaviour of unselecting an animated icon

### DIFF
--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -259,9 +259,9 @@ const IconsSet = (props) => {
   }
 
   const selectAnimatedIcon = (icon) => {
-    setIconSelected({ name: icon })
-    setShowPanel(true)
-    setSearchValue(icon)
+    setIconSelected({ name: icon } === iconSelected ? '' : { name: icon })
+    setShowPanel({ name: icon } !== iconSelected)
+    setSearchValue(icon === searchValue ? '' : icon)
     if (selectMultiple) {
       window.history.replaceState(
         '',


### PR DESCRIPTION
Fixes #107. Fix the default behavior of deselecting an icon in the animated icons section. 

Current behaviour - 

