### PR TITLE
fix behaviour on clicking on selected icon's tag

### DIFF
--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -48,7 +48,6 @@ const IconsSet = (props) => {
     if (urlTagName) setTagSelected(urlTagName)
     else {
       if (iconSelected !== '') {
-        setTagSelected('')
         tab === 'Static Icons'
           ? window.history.replaceState(
               '',
@@ -63,6 +62,16 @@ const IconsSet = (props) => {
       }
     }
   }, [urlTagName, iconSelected, tab])
+
+  useEffect(() => {
+    if (tagSelected && iconSelected === '') {
+      window.history.replaceState(
+        '',
+        'EOS Icons',
+        `${window.location.pathname}?tagName=${tagSelected}`
+      )
+    }
+  })
 
   const activeIconRef = useRef(null)
   useEffect(() => {
@@ -443,6 +452,7 @@ const IconsSet = (props) => {
               onClick={() => {
                 if (searchValue.length > 0) {
                   searchRef.current.value = ''
+                  setTagSelected('')
                   closeHowTo()
                 }
               }}

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -44,7 +44,7 @@ const IconsSet = (props) => {
   }
 
   useEffect(() => {
-    if (iconSelected !== '') {
+    if (iconSelected !== '' && !urlTagName) {
       tab === 'Static Icons'
         ? window.history.replaceState(
             '',
@@ -254,7 +254,7 @@ const IconsSet = (props) => {
       setSearchValue(urlTagName)
     }
 
-    if (!userSearchInput && urlIconName === null) {
+    if (!userSearchInput && urlTagName === null && urlIconName === null) {
       setSearchValue('')
     }
 

--- a/src/modules/IconsSet.js
+++ b/src/modules/IconsSet.js
@@ -32,6 +32,7 @@ const IconsSet = (props) => {
   const [suggestedString, setSuggestedString] = useState('')
   const [iconEditor, setIconEditor] = useState(false)
   const [userSearchInput, setUserSearchInput] = useState(false)
+  const [tagSelected, setTagSelected] = useState('')
 
   const iconEditorToggle = () => {
     setIconEditor(!iconEditor)
@@ -44,20 +45,24 @@ const IconsSet = (props) => {
   }
 
   useEffect(() => {
-    if (iconSelected !== '' && !urlTagName) {
-      tab === 'Static Icons'
-        ? window.history.replaceState(
-            '',
-            'EOS Icons',
-            `${window.location.pathname}?iconName=${iconSelected.name}&type=static`
-          )
-        : window.history.replaceState(
-            '',
-            'EOS Icons',
-            `${window.location.pathname}?iconName=${iconSelected.name}&type=animated`
-          )
+    if (urlTagName) setTagSelected(urlTagName)
+    else {
+      if (iconSelected !== '') {
+        setTagSelected('')
+        tab === 'Static Icons'
+          ? window.history.replaceState(
+              '',
+              'EOS Icons',
+              `${window.location.pathname}?iconName=${iconSelected.name}&type=static`
+            )
+          : window.history.replaceState(
+              '',
+              'EOS Icons',
+              `${window.location.pathname}?iconName=${iconSelected.name}&type=animated`
+            )
+      }
     }
-  })
+  }, [urlTagName, iconSelected, tab])
 
   const activeIconRef = useRef(null)
   useEffect(() => {
@@ -85,6 +90,7 @@ const IconsSet = (props) => {
     setAnimatedHistory('')
     setEmptySearchResult(false)
     setSuggestedString('')
+    setTagSelected('')
     resetTabsStateRef.current()
   }
 
@@ -254,7 +260,12 @@ const IconsSet = (props) => {
       setSearchValue(urlTagName)
     }
 
-    if (!userSearchInput && urlTagName === null && urlIconName === null) {
+    if (
+      !userSearchInput &&
+      urlTagName === null &&
+      urlIconName === null &&
+      tagSelected === ''
+    ) {
       setSearchValue('')
     }
 


### PR DESCRIPTION
Fixes #128. Fixes behavior on clicking the tags of a selected icon. URL and search parameters get populated or emptied accordingly, and the icons that are shown to the user also change accordingly.