### PR TITLE
fixed colored syntax highlighting in docs section

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -14,7 +14,8 @@ const Tabs = (props) => {
     toggleCustomize,
     showMultipleSwitch,
     currentTab,
-    resetTabsState
+    resetTabsState,
+    tabChangeHandler
   } = props
 
   const [activeTab, setActiveTab] = useState(currentTab)
@@ -33,12 +34,13 @@ const Tabs = (props) => {
   }, [customize, showPanel, windowsSize])
 
   useEffect(() => {
+    if (tabChangeHandler) tabChangeHandler()
     if (activeTab === 'Static Icons') {
       setChecked(staticCheck)
     } else {
       setChecked(false)
     }
-  }, [activeTab, staticCheck])
+  }, [activeTab, staticCheck, tabChangeHandler])
 
   const changeCheckedStatus = useCallback(() => {
     if (activeTab === currentTab) {

--- a/src/pages/Docs.js
+++ b/src/pages/Docs.js
@@ -10,7 +10,7 @@ import { Helmet } from 'react-helmet'
 import scrollToTop from '../utils/scrollToTop'
 
 const Docs = () => {
-  useEffect(() => {
+  const colorizeCodeSnippet = () => {
     Prism.highlightAll()
     scrollToTop()
 
@@ -25,6 +25,9 @@ const Docs = () => {
         }
       })
     }
+  }
+  useEffect(() => {
+    colorizeCodeSnippet()
   })
 
   return (
@@ -60,7 +63,11 @@ const Docs = () => {
       <div className='toolbar'></div>
 
       <div className='container no-padding'>
-        <Tabs showMultipleSwitch={false} currentTab={'In your application'}>
+        <Tabs
+          showMultipleSwitch={false}
+          currentTab={'In your application'}
+          tabChangeHandler={colorizeCodeSnippet}
+        >
           <div label='In your application'>
             <div className='container'>
               <h2>Installing EOS icons</h2>


### PR DESCRIPTION
Fixes #99. Fixes the issue of the sample code's syntax not getting color highlighted on changing tabs in the docs section.